### PR TITLE
Fix wrong filepaths (preview)

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -62,7 +62,7 @@ export class YarnSpinnerEditorProvider implements vscode.CustomTextEditorProvide
 
         this.executeCommand<NodeInfo[]>(
             Commands.ListNodes,
-            document.uri.toString())
+            document.uri.fsPath)
             .then(result => {
                 updateWebView(result);
             })
@@ -85,7 +85,7 @@ export class YarnSpinnerEditorProvider implements vscode.CustomTextEditorProvide
     }
 
     async openNode(document: vscode.TextDocument, id: string) {
-        var nodeInfos: NodeInfo[] = await this.executeCommand(Commands.ListNodes, document.uri.toString()) ?? [];
+        var nodeInfos: NodeInfo[] = await this.executeCommand(Commands.ListNodes, document.uri.fsPath) ?? [];
 
         // Filter to only include the node(s) that have this title. (Node names
         // must be unique, but the user may have entered invalid code, so we
@@ -122,7 +122,7 @@ export class YarnSpinnerEditorProvider implements vscode.CustomTextEditorProvide
         // for this node
         var documentEdit = await this.executeCommand<TextDocumentEdit>(
             Commands.UpdateNodeHeader,
-            document.uri.toString(),
+            document.uri.fsPath,
             nodeTitle,
             "position",
             `${Math.round(position.x)},${Math.round(position.y)}`
@@ -136,7 +136,7 @@ export class YarnSpinnerEditorProvider implements vscode.CustomTextEditorProvide
 
         var deletionEdit = await this.executeCommand<TextDocumentEdit>(
             Commands.RemoveNode, 
-            document.uri.toString(), 
+            document.uri.fsPath, 
             id
         );
 
@@ -151,7 +151,7 @@ export class YarnSpinnerEditorProvider implements vscode.CustomTextEditorProvide
 
         var edit = await this.executeCommand<TextDocumentEdit>(
             Commands.AddNode,
-            document.uri.toString(),
+            document.uri.fsPath,
             headers
         );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -156,7 +156,7 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand("yarnspinner.compile", () => {
         const params: ExecuteCommandParams = {
             command: "yarnspinner.compile",
-            arguments: [vscode.window.activeTextEditor?.document.uri.toString()]
+            arguments: [vscode.window.activeTextEditor?.document.uri.fsPath]
         };
     
         let compileRequest: Promise<CompilerOutput> = client.sendRequest(ExecuteCommandRequest.type, params);


### PR DESCRIPTION
On Windows, `document.uri.toString()` returns urlencoded string like `file:///v%3A/unity/...`, which is misinterpreted by language server.

Fixes #8