### PR TITLE
Added proper escape support + highlighting XML tags

### DIFF
--- a/syntaxes/yarnspinner.tmLanguage.json
+++ b/syntaxes/yarnspinner.tmLanguage.json
@@ -224,7 +224,35 @@
 						"name": "keyword.control"							
 					}
 				]
-			}]
+				},
+				{
+					"begin": "(?<!\\\\)\\<(?!\\<)",
+					"end": "\\>",
+					"name": "keyword.other.format_function",
+					"patterns": [
+						{
+							"name": "string.quoted.double.yarnspinner.format_function",
+							"begin": "\"",
+							"end": "\"",
+							"patterns": [
+								{
+									"name": "keyword.other.format_function.placeholder",
+									"match": "%"
+								},
+								{
+									"name": "constant.character.escape.yarnspinner.format_function",
+									"match": "\\\\."
+								}
+							]
+							
+						},
+						{
+							"match": "[^{=\\>]+",
+							"name": "keyword.control"		
+						}
+					]
+				}
+			]
 		}
 	},
 	"scopeName": "source.yarnspinner"

--- a/syntaxes/yarnspinner.tmLanguage.json
+++ b/syntaxes/yarnspinner.tmLanguage.json
@@ -42,7 +42,7 @@
 			]
 		},
 		"inline_expressions": {
-			"begin": "{",
+			"begin": "(?<!\\\\){",
 			"end": "}",
 			"name": "keyword.other",
 			"patterns": [
@@ -72,7 +72,7 @@
 			"patterns": [
 				{
 					"name": "keyword.other",
-					"begin": "\\<\\<",
+					"begin": "(?<!\\\\)\\<\\<",
 					"end": "\\>\\>",
 					"patterns": [
 						{
@@ -142,9 +142,14 @@
 		"lines": {
 			"patterns": [
 				{
+					"comment": "Escape Character",
+					"name": "constant.character.escape.yarnspinner",
+					"match": "(?<!\\\\)\\\\"
+				},
+				{
 					"comment": "Hashtags",
 					"name": "constant.language",
-					"match": "#[^\\s]+"
+					"match": "(?<!\\\\)#[^\\s]+"
 				},
 				{
 					"comment": "Name",
@@ -195,35 +200,36 @@
 			]
 		},
 		"format_functions": {
-			"patterns": [{
-				"begin": "\\[(?!\\[)",
-				"end": "\\]",
-				"name": "keyword.other.format_function",
-				"patterns": [
-					{
-						"include": "#inline_expressions"
-					},
-					{
-						"name": "string.quoted.double.yarnspinner.format_function",
-						"begin": "\"",
-						"end": "\"",
-						"patterns": [
-							{
-								"name": "keyword.other.format_function.placeholder",
-								"match": "%"
-							},
-							{
-								"name": "constant.character.escape.yarnspinner.format_function",
-								"match": "\\\\."
-							}
-						]
-						
-					},
-					{
-						"match": "[^{=\\]]+",
-						"name": "keyword.control"							
-					}
-				]
+			"patterns": [
+				{
+					"begin": "(?<!\\\\)\\[(?!\\[)",
+					"end": "\\]",
+					"name": "keyword.other.format_function",
+					"patterns": [
+						{
+							"include": "#inline_expressions"
+						},
+						{
+							"name": "string.quoted.double.yarnspinner.format_function",
+							"begin": "\"",
+							"end": "\"",
+							"patterns": [
+								{
+									"name": "keyword.other.format_function.placeholder",
+									"match": "%"
+								},
+								{
+									"name": "constant.character.escape.yarnspinner.format_function",
+									"match": "\\\\."
+								}
+							]
+							
+						},
+						{
+							"match": "[^{=\\]]+",
+							"name": "keyword.control"							
+						}
+					]
 				},
 				{
 					"begin": "(?<!\\\\)\\<(?!\\<)",


### PR DESCRIPTION
![16_20-44_Code](https://user-images.githubusercontent.com/1772788/184861122-6e5b4105-48e0-450e-a3b4-5cd72ac43faf.png)

(Using `tests/input/Escaping.yarn`)

Previously, syntax highlighting broke when trying to escape special characters. Matches now do a negative lookbehind to check if they're not being escaped.

Included support for XML/TextMeshPro-style angle brace tags. This isn't explicitly part of the syntax, but it's a nice QOL addition that targets the common use case of people writing in Yarn and using TextMeshPro.