### PR TITLE
Add yarnspinner.tag-lines command

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,12 @@
                 "category": "Yarn Spinner",
                 "title": "Create New Yarn Project...",
                 "enablement": "yarnspinner.languageServerLaunched"
+            },
+            {
+                "command": "yarnspinner.tag-lines",
+                "category": "Yarn Spinner",
+                "title": "Add Yarn Spinner line tags",
+                "enablement": "yarnspinner.languageServerLaunched"
             }
         ],
         "configurationDefaults": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -555,6 +555,67 @@ async function launchLanguageServer(context: vscode.ExtensionContext, configs: v
         vscode.commands.executeCommand('revealInExplorer', destinationUri);
     }))
 
+    context.subscriptions.push(vscode.commands.registerCommand("yarnspinner.tag-lines", async () => {
+
+        const uri = await getOrChooseProjectUri();
+        if (!uri) {
+            return;
+        }
+
+        const params: languageClient.ExecuteCommandParams = {
+            command: "yarnspinner.tag-lines",
+            arguments: [
+                uri.toString()
+            ]
+        };
+
+        let request: Promise<languageClient.WorkspaceEdit> = client.sendRequest(languageClient.ExecuteCommandRequest.type, params);
+        request.then(result => {
+            try{
+                
+            var workspaceEdit = new vscode.WorkspaceEdit(); 
+            var documentChanges = result.documentChanges ?? [];
+            for (const documentChange of documentChanges) {
+                const docEdit = documentChange as languageClient.TextDocumentEdit;
+                if (!docEdit) {
+                    continue;
+                }
+                // Parse the uri string into a vscode.Uri
+                const documentUri = vscode.Uri.parse(docEdit.textDocument.uri);
+                for(const edit of docEdit.edits) {
+
+                    // Convert the language server Range to a vscode.Range
+                    const editRange = new vscode.Range(
+                        edit.range.start.line, edit.range.start.character,
+                        edit.range.end.line, edit.range.end.character
+                    );
+        
+                    // Add the replacement
+                    workspaceEdit.replace(documentUri, editRange, edit.newText);
+                }
+            }
+            if(documentChanges.length == 0) {
+                vscode.window.showInformationMessage(`All lines in the file are already tagged.`);
+                return;
+            }
+            vscode.workspace.applyEdit(workspaceEdit).then(done => 
+                { 
+                    if (!done) {
+                        vscode.window.showErrorMessage("Unable to add tags to lines.");
+                        return;
+                    }
+                    vscode.window.showInformationMessage(`Tagged lines successfully!`);
+                }
+            ); // Apply the workspace edit returned by the server
+            } catch (error: any) {
+             vscode.window.showErrorMessage(`Unable to add tags to lines: ${error?.message}`);
+            }
+            
+        }).catch(error =>{
+            vscode.window.showErrorMessage("Error in the language server: " + error.toString());
+        });
+    }));
+
     // Enable commands that depend upon the language server being online and the above commands being registered
     vscode.commands.executeCommand('setContext', 'yarnspinner.languageServerLaunched', true);
 


### PR DESCRIPTION
This PR exposes to the user, and applies the response of the `tag-lines` language server command added in this corresponding PR: https://github.com/YarnSpinnerTool/YarnSpinner/pull/409 

Starting this out as a draft PR until tests are added and the [language server PR](https://github.com/YarnSpinnerTool/YarnSpinner/pull/409) can get merged in (don't want to expose functionality before it works!).