### PR TITLE
Add new exportWorkspace command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -595,7 +595,7 @@ async function launchLanguageServer(
             let compileResult: Promise<YarnData | null> =
                 compileWorkspace(client);
 
-            compileResult
+            return compileResult
                 .then((result) => {
                     return result;
                 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -588,6 +588,20 @@ async function launchLanguageServer(
         }),
     );
 
+    // perform a compilation and return the output (used to export to other VSCode extensions)
+    // Error handling / user-facing error messaging handled by the caller
+    context.subscriptions.push(
+        vscode.commands.registerCommand("yarnspinner.exportWorkspace", () => {
+            let compileResult: Promise<YarnData | null> =
+                compileWorkspace(client);
+
+            compileResult
+                .then((result) => {
+                    return result;
+                });
+        }),
+    );
+
     // ask the LSP to make a graph file and then save that
     // recording strings extraction command
     context.subscriptions.push(


### PR DESCRIPTION
This PR adds a new `exportWorkspace` command which compiles a project and returns the results. It uses the same existing functionality as the `exportPreview` / `showPreview` commands but stops before doing any further conversion. This would be useful for interop with other vscode extensions (my use case is an extension to support my WIP playdate port, but could imagine this also enabling lot of small bespoke tools to analyze/manage yarnspinner projects).