### PR TITLE
Auto create a github tag on [release] commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,11 @@ jobs:
         # The type of runner that the job will run on
         runs-on: ubuntu-latest
 
+        # Allow write permissions to push a tag to github when the commit contains '[release]'
+        # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions
+        permissions:
+          contents: write
+
         # Steps represent a sequence of tasks that will be executed as part of the job
         steps:
             # Check out the repo
@@ -97,3 +102,11 @@ jobs:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
               run: |
                   npx vsce publish ${{ env.RELEASE_FLAG }}  -i ${{github.workspace}}/yarn-spinner-${{steps.version.outputs.MajorMinorCommits}}.vsix
+
+            #  If is a push, and the commit message does contain the string
+            #  '[release]', tag as release.
+            - name: Tag release
+              if: ${{ github.event_name == 'push' && contains(github.event.head_commit.message, '[release]' ) }}
+              run: |
+                  git tag ${{ steps.version.outputs.MajorMinorCommits }}
+                  git push origin ${{ steps.version.outputs.MajorMinorCommits }}


### PR DESCRIPTION
It would be nice to have the release commits tagged automatically in github with the same version as the extension.

This makes it much easier to find changes between releases like this: https://github.com/YarnSpinnerTool/VSCodeExtension/compare/v2.2.15...v2.2.77

Because right now I have an issue ( https://github.com/YarnSpinnerTool/IssuesDiscussion/issues/58 ) but I can not quickly see what has changed between two versions, because the repository does not use version tags yet.

Example/test repo:

- https://github.com/rboonzaijer/auto-tag-release
- https://github.com/rboonzaijer/auto-tag-release/actions
- https://github.com/rboonzaijer/auto-tag-release/tags